### PR TITLE
Reformatted arguments in scatterplot

### DIFF
--- a/app/utils/visualizations/line_graph.py
+++ b/app/utils/visualizations/line_graph.py
@@ -21,12 +21,16 @@ def line_graph(score_history, name):
         data=go.Scatter(
             x=[i + 1 for i in range(len(score_history))],
             y=score_history,
-            line_width=7,
-            line_color="#EB7E5B",
+            line={
+                'width': 7,
+                'color': '#EB7E5B'
+            },
             mode="lines+markers+text",
-            marker_size=18,
-            marker_color="#FED23E",
-            marker_symbol="star",
+            marker={
+                'size': 18,
+                'color': '#FED23E',
+                'symbol': 'star'
+            }
         )
     )
 


### PR DESCRIPTION
# Data Science PR Template

---

[Link to the PR Rubric](https://www.notion.so/1fc04e4fedeb429ba873b7c68d281707?v=74054da7991341c0bf970f39410c43da)

---

( BELOW IS AN EXAMPLE )

---

[Related Trello Card](https://trello.com/c/dvNrf0pn)

---

### Location:

- app/utils/visualizations/line_graph.py

---

### Details:

Reformatted the arguments in the setup for the scatterplot because they were not formatted properly according to Plotly's documentation. The arguments that I changed were the following:

1. The `line` argument - turned it into a dictionary
2. The `marker` argument - turned it into a dictionary 

---

### Committed Features:

1. Reformatted the line and marker arguments in the scatterplot

---

### Any Issues:

None.