### PR TITLE
Added instructions for deploying locally on Windows machine in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ It is possible to deploy this API locally on a Windows 10 machine. There are som
 
 * In the same file and function as above, you need to also change: `environ["GOOGLE_APPLICATION_CREDENTIALS"] = "/tmp/google.json"` (currently line 41) to : `environ["GOOGLE_APPLICATION_CREDENTIALS"] = "././app/tmp/google.json"`
 
+  * ***NOTE:*** If the above path does not work for you, you can try to replace `"/tmp/google.json"` with `"app/tmp/google.json"`, which is the path from the repository root.
+
 * Then in the `app` directory you need to create a new directory called `tmp`.
 
 * In the `tmp` directory, create an empty file named `google.json`

--- a/README.md
+++ b/README.md
@@ -138,6 +138,30 @@ Given that this project will have future teams of data scientists building off o
    - Of course, a more sophisticated clustering algorithm would be preferred. In order to avoid re-transcribing stories (which would take a lot of extra time, and would add to the Google Cloud bill), either the web database could store transcriptions after initial submission, or DS could generate its own database. Note that if DS creates its own database, it needs to have the same considerations that Web’s does: i.e. how to handle stories that are moderated out of gamification, etc.
 
 ## Deployment
+     
+### How to Deploy locally on a Windows Machine:
+
+It is possible to deploy this API locally on a Windows 10 machine. There are some changes that you will need to make in order to do so. There are other options for local deployment on a Windows machine that does not involve making changes, such as running a Linux Ubuntu WSL. This is just another option if you are unable to use one of the other methods.
+
+* If you have `Python 3.9` on your machine, you will have to specify which version of Python you want your environment to use because there are packages in the `Pipfile` that are not compatible with the 3.9 version of Python yet. Otherwise, the computer will automatically select the most recent version of Python that you have on your machine, if you do not specify which version you want it to use for this environment.
+  
+  * In this case, when you set up your environment, you will need to run the following command: `pipenv --python 3.8 install --dev`. You can also use Python 3.7, just change the 3.8 to 3.7 when you run the command. 
+
+* Then you need to go to `app/utils/img_processing/google_api.py` and locate the code: `with open("/tmp/google.json", "wt") as fp:` in the `__init__` function (currently it is line 32) and change that to: `with open("././app/tmp/google.json", "wt") as fp:`
+
+* In the same file and function as above, you need to also change: `environ["GOOGLE_APPLICATION_CREDENTIALS"] = "/tmp/google.json"` (currently line 41) to : `environ["GOOGLE_APPLICATION_CREDENTIALS"] = "././app/tmp/google.json"`
+
+* Then in the `app` directory you need to create a new directory called `tmp`.
+
+* In the `tmp` directory, create an empty file named `google.json`
+
+* Now you should be all set to run `uvicorn app.main:app --reload` to deploy the API locally, provided you have the proper credentials. 
+
+  > ***NOTE:***  
+  > **Do NOT push these changes to GitHub!**  
+  > These changes need to remain on your local machine only!
+
+
 ### **Infrastructure**
 The infrastructure is handled by AWS Elastic Beanstalk Service using Docker containers.
 

--- a/README.md
+++ b/README.md
@@ -141,11 +141,11 @@ Given that this project will have future teams of data scientists building off o
      
 ### How to Deploy locally on a Windows Machine:
 
-It is possible to deploy this API locally on a Windows 10 machine. There are some changes that you will need to make in order to do so. There are other options for local deployment on a Windows machine that does not involve making changes, such as running a Linux Ubuntu WSL. This is just another option if you are unable to use one of the other methods.
+It is possible to deploy this API locally on a Windows 10 machine. There are some changes that you will need to make to do so. There are other options for local deployment on a Windows machine that does not involve making changes, such as running a Ubuntu WSL (Windows Subsystem for Linux). 
 
-* If you have `Python 3.9` on your machine, you will have to specify which version of Python you want your environment to use because there are packages in the `Pipfile` that are not compatible with the 3.9 version of Python yet. Otherwise, the computer will automatically select the most recent version of Python that you have on your machine, if you do not specify which version you want it to use for this environment.
+* If you have `Python 3.9` on your machine, you will have to specify which version of Python you want your environment to use because some packages in the `Pipfile` are not compatible with the 3.9 version of Python yet. Otherwise, the computer will automatically select the most recent version of Python that you have on your machine if you do not specify which version you want to use for this environment.
   
-  * In this case, when you set up your environment, you will need to run the following command: `pipenv --python 3.8 install --dev`. You can also use Python 3.7, just change the 3.8 to 3.7 when you run the command. 
+  * In this case, when you set up your environment, you will need to run the following command: `pipenv --python 3.8 install --dev`. You can also use Python 3.7. Just change the 3.8 to 3.7 when you run the command. 
 
 * Then you need to go to `app/utils/img_processing/google_api.py` and locate the code: `with open("/tmp/google.json", "wt") as fp:` in the `__init__` function (currently it is line 32) and change that to: `with open("././app/tmp/google.json", "wt") as fp:`
 
@@ -153,11 +153,11 @@ It is possible to deploy this API locally on a Windows 10 machine. There are som
 
   * ***NOTE:*** If the above path does not work for you, you can try to replace `"/tmp/google.json"` with `"app/tmp/google.json"`, which is the path from the repository root.
 
-* Then in the `app` directory you need to create a new directory called `tmp`.
+* Then, in the `app` directory, you need to create a new directory called `tmp`
 
 * In the `tmp` directory, create an empty file named `google.json`
 
-* Now you should be all set to run `uvicorn app.main:app --reload` to deploy the API locally, provided you have the proper credentials. 
+* Now, you should be all set to run `uvicorn app.main:app --reload` to deploy the API locally, provided you have the proper credentials. 
 
   > ***NOTE:***  
   > **Do NOT push these changes to GitHub!**  


### PR DESCRIPTION
# Added Instructions for Deploying API locally on a Windows Machine

---

[Link to the PR Rubric](https://www.notion.so/1fc04e4fedeb429ba873b7c68d281707?v=74054da7991341c0bf970f39410c43da)

---

[Related Trello Card](https://trello.com/c/PTlynJuI)

---

### Location:

- `README.md`

---

### Details:

1. Under the "Deployment" section of the main `README.md` file, I added the instructions on how I was able to make deployment of the API work locally on my Windows 10 Home machine without having to use Linux WSL. 

---

### Committed Features:
1. Added instructions for deploying locally on Windows.
2. Added another path option

---

### Any Issues:
- No issues to report.