### PR TITLE
Utility to filter and display if any image in the data directory could be child's full essay.

### DIFF
--- a/utils/README.md
+++ b/utils/README.md
@@ -1,0 +1,32 @@
+**Explanation of essaycheck_script.py**
+
+**How to Run This Script:**
+
+Place the script in the repo's top-level directory. cd into the repo from the command line and enter the following:
+```angular2html
+python essaycheck_script.py
+```
+
+**What it Does:**
+
+The essaycheck_script.py file scans the repo for image files that potentially might be full essays.
+
+**What it Finds:**
+
+The script finds files with the following extensions:
+    * .png
+    * .jpg
+    * .tif
+
+The script returns the total number of image files along with a breakdown of the totals for image files in the following two categories:
+1. Files that are likely to be full essays 
+2. Files that are likely to be individual snippets
+
+**What the Script Does Not Do:**
+
+The script does not remove the files that it finds. The user will need to make a determination about whether a file was inadvertently pushed and needs to be removed to comply with COPPA regulations.
+
+The threshold for determining whether or not a file is likely to be a snippet or a full original essay currently is 
+determined by its file size. Any files greater than 260000 bytes are possibly full essay images.
+
+_Note: This script will be refactored shortly to have an additional check based on file dimensions to further increase the accuracy of the results._

--- a/utils/essaycheck_w_image_height.py
+++ b/utils/essaycheck_w_image_height.py
@@ -1,16 +1,48 @@
+import os
+
+import cv2
 from PIL import Image
 
-# Test using a full essay
-image = Image.open("/Users/rob/Downloads/starysquad-ground-truth-10-documents-summary/All_Data/Photo 3121.jpg")
-width, height = image.size
-# extract width and height from output tuple
 
-print(width, height)
+def full_essay_checker(directory, max_height):
+    """
+    :param directory:
+    :param max_height:
+    :return: None
+    This function will generate and display the files in the directory
+    passed in the arguments above by walking the tree and checking
+    if any of the .png, .tif, .jpg or .jpeg file in the directory
+    is not having too much height which may be the indicator of a full
+    child story that should not be publicly accessible due to child's safety.
+    """
+    # Check if the directory exists
+    if os.path.isdir(directory):
+        max_height = max_height  # This number can be changed in order to come up with
+        # Walk the directory
+        for root, directories, files in os.walk(directory):
+            for filename in files:
+                # Get file paths with specific extensions
+                if filename.endswith(".png") or filename.endswith(".tif") \
+                        or filename.endswith(".jpg") or filename.endswith(".jpeg"):
+                    file_to_check = os.path.join(root, filename)
 
-# Test using a sample snippet
-image = Image.open("/Users/rob/GitHubProjects/scribble-stadium-ds/data/storysquad-ground-truth-51/5125/51-5125-1-0.png")
+                    # Get image dimensions
+                    image = Image.open(file_to_check)
+                    width, height = image.size
 
-width, height = image.size
-# extract width and height from output tuple
+                    # Check if the image height is more than the max_height
+                    # if it is then print file name:height in console and display to the user
+                    if height > max_height:
+                        print('Potential Full Essay Information (file:height shown) -->', file_to_check, height)
+                        # Display the image to the user
+                        img = cv2.imread(file_to_check)
+                        cv2.imshow('Potential Full Essay Image {Press any key to continue}', img)
+                        cv2.waitKey(0)
+                        cv2.destroyAllWindows()
+    else:
+        print('Directory not accessible!')
 
-print(width, height)
+
+# Run the function to find the files that do not have a corresponding txt files
+full_essay_checker(directory="../data",
+                   max_height=200)  # max_height can be changed for any other threshold

--- a/utils/essaycheck_w_image_height.py
+++ b/utils/essaycheck_w_image_height.py
@@ -1,0 +1,16 @@
+from PIL import Image
+
+# Test using a full essay
+image = Image.open("/Users/rob/Downloads/starysquad-ground-truth-10-documents-summary/All_Data/Photo 3121.jpg")
+width, height = image.size
+# extract width and height from output tuple
+
+print(width, height)
+
+# Test using a sample snippet
+image = Image.open("/Users/rob/GitHubProjects/scribble-stadium-ds/data/storysquad-ground-truth-51/5125/51-5125-1-0.png")
+
+width, height = image.size
+# extract width and height from output tuple
+
+print(width, height)

--- a/utils/essaycheck_w_image_height.py
+++ b/utils/essaycheck_w_image_height.py
@@ -6,8 +6,9 @@ from PIL import Image
 
 def full_essay_checker(directory, max_height):
     """
-    :param directory:
-    :param max_height:
+    :param directory: Directory of interest
+    :param max_height: Height threshold beyond which a file should be
+            flagged as a potential child essay.
     :return: None
     This function will generate and display the files in the directory
     passed in the arguments above by walking the tree and checking


### PR DESCRIPTION
Description for this pull request --> This pull request is to request the addition of a utility in the util folder that checks and displays all image files that could potentially be a child's full essay. This utility can be used in addition to the already existing utility that checks if an image is a potential child's full essay based on image size. The utility allows for flexibility in setting the directory and setting different image threshold heights (the basis on which the images are filtered). 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

## Change Status

- [X] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

## Has This Been Tested

- [X] Yes
- [ ] No
- [ ] Not necessary

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] There are no merge conflicts

[Trello Card](https://trello.com/c/hOh48vsE/478-clean-up-full-scan-essay-images-in-the-ds-repo)
[Loom Video](https://www.loom.com/share/6093b48e1d504b75998f1ec1f41c43bd)