### PR TITLE
Removes .gitmodules that was missed on the convert2tif deletion PR #119

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "convert2tif"]
-	path = convert2tif
-	url = https://github.com/dakotagporter/convert2tif


### PR DESCRIPTION
# Description

This PR removes the .gitmodules directory that was missed in the convert2tif deletion, PR #119. 

## Type of change

- [x] Removing dead or superfluous code

## Change Status

- [x] Complete, tested, ready to review and merge

## Has This Been Tested

- [x] Not necessary

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts

Loom Video: https://www.loom.com/share/35a2e2cd87674ecd991e96d61a62f29d